### PR TITLE
Implement top workplaces script

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -12,7 +12,7 @@
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
-    "start:topWorkplaces": "npm run start:topWorkplaces:ts",
+    "start:topWorkplaces": "npm run start:topWorkplaces:js",
     "start:topWorkplaces:ts": "ts-node src/scripts/top-workplaces.ts",
     "start:topWorkplaces:js": "node src/scripts/top-workplaces.js",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",

--- a/server/src/scripts/top-workplaces.js
+++ b/server/src/scripts/top-workplaces.js
@@ -1,1 +1,33 @@
-console.log("TODO: Implement me!");
+const fs = require('fs');
+
+function loadArray(file) {
+  let text = fs.readFileSync(file, 'utf8');
+  text = text.replace(/^import[^\n]*\n/, '');
+  text = text.replace(/export const \w+:[^=]*=\s*/, '');
+  text = text.replace(/;\s*$/, '');
+  return eval(text); // parse as JS
+}
+
+function main() {
+  const shifts = loadArray('./prisma/seed/shifts.ts');
+  const workplaces = loadArray('./prisma/seed/workplaces.ts');
+
+  const counts = {};
+  for (const shift of shifts) {
+    if (shift.worker && !shift.cancelledAt) {
+      const id = shift.workplace.connect.id;
+      counts[id] = (counts[id] || 0) + 1;
+    }
+  }
+
+  const active = workplaces
+    .map((w, i) => ({ id: i + 1, name: w.name, status: w.status }))
+    .filter((w) => w.status === 0)
+    .map((w) => ({ name: w.name, shifts: counts[w.id] || 0 }));
+
+  active.sort((a, b) => b.shifts - a.shifts);
+  const top = active.slice(0, 3);
+  console.log(JSON.stringify(top, null, 2));
+}
+
+main();


### PR DESCRIPTION
## Summary
- implement `top-workplaces.js` to parse seed data and output the top active workplaces
- update `start:topWorkplaces` script to run the JavaScript implementation

## Testing
- `npm run start:topWorkplaces --silent`

------
https://chatgpt.com/codex/tasks/task_b_68717158d99c832999f91d738d7dc084